### PR TITLE
Create For-V2.5.1-All.css

### DIFF
--- a/For-V2.5.1-All.css
+++ b/For-V2.5.1-All.css
@@ -1,0 +1,275 @@
+/* 所有界面元素的样式,均为先浅色后深色的顺序 */
+
+/* 全局 */
+section {
+    background-color: rgba(255, 255, 255, 0) !important;
+}
+
+html {
+    --background-color: #f0f0f000 !important;
+}
+
+/* 首页按钮-选中*/
+.css-1hlek36 {}
+
+.css-14aadh2,
+.css-1dxee5s {
+    background-color: rgb(0, 95, 199) !important;
+}
+
+
+/* 左侧标签背景 */
+.css-a7awl9.Mui-selected {
+    background-color: #d4f0fc37 !important;
+    backdrop-filter: blur(7px);
+}
+
+.css-1pqmd8p.Mui-selected {
+    background-color: #383c3d37 !important;
+    backdrop-filter: blur(7px);
+}
+
+/*防止左侧标签中的图标与文字重叠并整体居中*/
+.the-menu .MuiListItemButton-root {
+    justify-content: center !important;
+}
+
+.the-menu .MuiListItemText-root {
+    flex: none !important;
+    text-align: left !important;
+    margin: 0 6px 0 0 !important;
+}
+
+.the-menu .MuiListItemIcon-root {
+    min-width: 0 !important;
+    flex-shrink: 0 !important;
+    margin: 0 6px 0 6px !important;
+}
+
+/* 左侧标签字体 */
+.css-a7awl9 span {
+    color: #0f0f0f !important;
+    text-shadow:
+        0 0 10px rgb(146 187 207);
+}
+
+.css-1pqmd8p span {
+    color: #e3e3e3 !important;
+    text-shadow:
+        0 0 15px rgb(66 88 99);
+}
+
+
+/* 全局背景图 */
+.css-1li7dvq {
+    background-image: url('https://pic.imgdb.cn/item/669377dbd9c307b7e9726828.png') !important;
+    background-color: rgba(255, 255, 255, 0) !important;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.css-l3ykv8 {
+    background-image: url('https://pic1.imgdb.cn/item/68823f1d58cb8da5c8d74300.jpg') !important;
+    background-color: rgba(255, 255, 255, 0) !important;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    color: rgb(239, 239, 239) !important;
+}
+
+
+
+/* 首页按钮 */
+.css-buo882,
+.css-1woqkq7 {
+    background-color: #ffffff66 !important;
+    backdrop-filter: blur(7px) !important;
+}
+
+.css-6892g4,
+.css-1j1wdi0 {
+    background-color: #00000044 !important;
+    backdrop-filter: blur(7px) !important;
+}
+
+
+
+
+/* 节点、测试站点条目 */
+.css-n8e8d,
+.css-1d9xrv7,
+.css-9kkeku {
+    background-color: #ffffff22 !important;
+    backdrop-filter: blur(10px) !important;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+}
+
+.css-jtgpy6,
+.css-1mxksna,
+.css-1tg4gst {
+    background-color: #00000022 !important;
+    backdrop-filter: blur(10px) !important;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+}
+
+/* 首页统计图 */
+.MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded.MuiPaper-elevation0.css-1unmb9x {
+    background-color: #ffffff33 !important;
+    backdrop-filter: blur(7px) !important;
+    border-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded.MuiPaper-elevation0.css-um6u34 {
+    background-color: #00000033 !important;
+    backdrop-filter: blur(7px) !important;
+    border-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+
+
+
+/* 连接页表格*/
+.MuiDataGridVariables-583896634,
+.MuiDataGridVariables-2433827283 {
+    --DataGrid-t-color-background-base: #ffffff00 !important;
+    --DataGrid-t-header-background-base: #ffffff00 !important;
+    backdrop-filter: blur(7px) !important;
+}
+
+
+/* 通用圆角卡片 */
+.css-14wd3ve,
+.css-23cvz {
+    backdrop-filter: blur(7px) !important;
+    border-radius: 15px;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+}
+
+/* 首页监控数据 */
+.css-fiq9q0 {
+    backdrop-filter: blur(7px) !important;
+}
+
+
+/* MuiBox 基础样式 - 全局透明背景 */
+.MuiBox-root {
+    background-color: rgba(255, 255, 255, 0) !important;
+}
+
+.base-container {
+    background-color: #f0f0f000 !important;
+}
+
+.MuiTypography-root {
+    background-color: rgba(0, 0, 0, 0) !important;
+}
+
+/* 菜单布局 */
+.the-menu {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+}
+
+.the-menu li {
+    flex: 0 0 50%;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+}
+
+.the-menu::after {
+    content: "";
+    flex: 0 0 50%;
+    /* 用于在项目数为奇数时填补布局 */
+}
+
+.layout__left {
+    height: 100% !important;
+    flex: 1 0 400px !important;
+}
+
+.the-traffic {
+    margin-top: 30%;
+}
+
+/* 设置中条目的文字 */
+.css-1i24pk4 {
+    background-color: transparent !important;
+}
+
+/* 设置条目背景-含icon、选择按钮与节点背景 */
+.css-1ohqk82.MuiButtonBase-root,
+.css-ulr2qx,
+div[data-index] {
+    background-color: #ffffff00 !important;
+}
+
+.css-17rlh6j {
+    background-color: #00000022 !important;
+    backdrop-filter: blur(10px) !important;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+}
+
+.css-ulr2qx {
+    background-color: #ffffff22 !important;
+    backdrop-filter: blur(10px) !important;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+}
+
+
+/* 特定 MuiBox 实例的背景模糊效果 */
+/* 流量图显 */
+.MuiBox-root.css-79elbk {
+    /* background-color 已由 .MuiBox-root 设置为透明 */
+    backdrop-filter: blur(2px);
+}
+
+/* 以下 MuiBox 实例明确不需要背景模糊 */
+/* 栏间空隙 */
+/* 网速监控 */
+/* 内存占用 */
+.MuiBox-root.css-mbssy4,
+.MuiBox-root.css-1ueg5w,
+.MuiBox-root.css-7bkud2 {
+    /* background-color 已由 .MuiBox-root 设置为透明 */
+    backdrop-filter: none;
+}
+
+
+
+
+
+/* 界面左上角图标自定义示例 */
+/*
+.the-logo > div svg:first-of-type {
+    display: none;
+}
+
+.the-logo > div::after {
+    content: '';
+    display: block;
+    width: 46px;
+    height: 46px;
+    left: 5px;
+    bottom: 8px;
+    background-image: url('https://www.example.com/1.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    position: absolute;
+}
+
+.the-logo > div svg:nth-of-type(2) {
+    display: block;
+    margin-left: 40px;
+}
+*/

--- a/For-V2.5.2-All.css
+++ b/For-V2.5.2-All.css
@@ -1,0 +1,290 @@
+/* 所有界面元素的样式,均为先浅色后深色的顺序 */
+
+/* 全局 */
+section {
+    background-color: rgba(255, 255, 255, 0) !important;
+}
+
+html {
+    --background-color: #f0f0f000 !important;
+}
+
+/* 首页按钮-选中*/
+.css-1hlek36 {}
+
+.css-14aadh2,
+.css-1dxee5s {
+    background-color: rgb(0, 95, 199) !important;
+}
+
+
+/* 左侧标签背景 */
+.css-a7awl9.Mui-selected {
+    background-color: #d4f0fc37 !important;
+    backdrop-filter: blur(7px);
+}
+
+.css-1pqmd8p.Mui-selected {
+    background-color: #383c3d37 !important;
+    backdrop-filter: blur(7px);
+}
+
+/*防止左侧标签中的图标与文字重叠并整体居中*/
+.the-menu .MuiListItemButton-root {
+    justify-content: center !important;
+}
+
+.the-menu .MuiListItemText-root {
+    flex: none !important;
+    text-align: left !important;
+    margin: 0 6px 0 0 !important;
+}
+
+.the-menu .MuiListItemIcon-root {
+    min-width: 0 !important;
+    flex-shrink: 0 !important;
+    margin: 0 6px 0 6px !important;
+}
+
+/* 左侧标签字体 */
+.css-a7awl9 span {
+    color: #0f0f0f !important;
+    text-shadow:
+        0 0 10px rgb(146 187 207);
+}
+
+.css-1pqmd8p span {
+    color: #e3e3e3 !important;
+    text-shadow:
+        0 0 15px rgb(66 88 99);
+}
+
+
+/* 全局背景图 */
+.css-1li7dvq {
+    background-image: url('https://pic.imgdb.cn/item/669377dbd9c307b7e9726828.png') !important;
+    background-color: rgba(255, 255, 255, 0) !important;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.css-l3ykv8 {
+    background-image: url('https://pic1.imgdb.cn/item/68823f1d58cb8da5c8d74300.jpg') !important;
+    background-color: rgba(255, 255, 255, 0) !important;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    color: rgb(239, 239, 239) !important;
+}
+
+
+
+/* 首页按钮 */
+.css-buo882,
+.css-1woqkq7 {
+    background-color: #ffffff66 !important;
+    backdrop-filter: blur(7px) !important;
+}
+
+.css-6892g4,
+.css-1j1wdi0 {
+    background-color: #00000044 !important;
+    backdrop-filter: blur(7px) !important;
+}
+
+
+
+
+/* 节点、测试站点条目 */
+.css-n8e8d,
+.css-1d9xrv7,
+.css-9kkeku {
+    background-color: #ffffff22 !important;
+    backdrop-filter: blur(10px) !important;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+}
+
+.css-jtgpy6,
+.css-1mxksna,
+.css-1tg4gst {
+    background-color: #00000022 !important;
+    backdrop-filter: blur(10px) !important;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+}
+
+/* 首页统计图 */
+.MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded.MuiPaper-elevation0.css-1unmb9x {
+    background-color: #ffffff33 !important;
+    backdrop-filter: blur(7px) !important;
+    border-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded.MuiPaper-elevation0.css-um6u34 {
+    background-color: #00000033 !important;
+    backdrop-filter: blur(7px) !important;
+    border-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+/* 通用圆角卡片 */
+.css-14wd3ve,
+.css-23cvz {
+    backdrop-filter: blur(7px) !important;
+    border-radius: 15px;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+}
+
+/* 首页监控数据 */
+.css-fiq9q0 {
+    backdrop-filter: blur(7px) !important;
+}
+
+
+/* MuiBox 基础样式 - 全局透明背景 */
+.MuiBox-root {
+    background-color: rgba(255, 255, 255, 0) !important;
+}
+
+.base-container {
+    background-color: #f0f0f000 !important;
+}
+
+.MuiTypography-root {
+    background-color: rgba(0, 0, 0, 0) !important;
+}
+
+/* 菜单布局 */
+.the-menu {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+}
+
+.the-menu li {
+    flex: 0 0 50%;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+}
+
+.the-menu::after {
+    content: "";
+    flex: 0 0 50%;
+    /* 用于在项目数为奇数时填补布局 */
+}
+
+.layout__left {
+    height: 100% !important;
+    flex: 1 0 400px !important;
+}
+
+.the-traffic {
+    margin-top: 30%;
+}
+
+/* 设置中条目的文字 */
+.css-1i24pk4 {
+    background-color: transparent !important;
+}
+
+/* 设置条目背景-含icon、选择按钮、连接页表头与节点背景 */
+div[style*="position: sticky"]>div {
+    background-color: #ffffff00 !important;
+}
+
+.css-17rlh6j,
+.css-nr2a57 {
+    backdrop-filter: blur(10px) !important;
+}
+
+.css-17rlh6j {
+    background-color: #00000022 !important;
+    transition: background-color 150ms cubic-bezier(0.8, 0, 0.6, 1);
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0);
+    /* 羽化效果 */
+    transition: box-shadow 150ms cubic-bezier(0.8, 0, 0.6, 1) !important;
+}
+
+/* 下拉置顶后样式 */
+.css-nr2a57 {
+    background-color: #00000050 !important;
+    transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+    transition: box-shadow 150ms cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+
+.css-ulr2qx,
+.css-1ssn8mg {
+    backdrop-filter: blur(10px) !important;
+}
+
+.css-ulr2qx {
+    background-color: #ffffff22 !important;
+    transition: background-color 150ms cubic-bezier(0.8, 0, 0.6, 1);
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0);
+    /* 羽化效果 */
+    transition: box-shadow 150ms cubic-bezier(0.8, 0, 0.6, 1) !important;
+}
+
+/* 下拉置顶后样式 */
+.css-1ssn8mg {
+    background-color: #ffffff50 !important;
+    transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.05);
+    /* 羽化效果 */
+    transition: box-shadow 150ms cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+
+/* 特定 MuiBox 实例的背景模糊效果 */
+/* 流量图显 */
+.MuiBox-root.css-79elbk {
+    /* background-color 已由 .MuiBox-root 设置为透明 */
+    backdrop-filter: blur(2px);
+}
+
+/* 以下 MuiBox 实例明确不需要背景模糊 */
+/* 栏间空隙 */
+/* 网速监控 */
+/* 内存占用 */
+.MuiBox-root.css-mbssy4,
+.MuiBox-root.css-1ueg5w,
+.MuiBox-root.css-7bkud2 {
+    /* background-color 已由 .MuiBox-root 设置为透明 */
+    backdrop-filter: none;
+}
+
+
+
+
+
+/* 界面左上角图标自定义示例 */
+/*
+.the-logo > div svg:first-of-type {
+    display: none;
+}
+
+.the-logo > div::after {
+    content: '';
+    display: block;
+    width: 46px;
+    height: 46px;
+    left: 5px;
+    bottom: 8px;
+    background-image: url('https://www.example.com/1.png');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    position: absolute;
+}
+
+.the-logo > div svg:nth-of-type(2) {
+    display: block;
+    margin-left: 40px;
+}
+*/


### PR DESCRIPTION
修复了2.5.1&2.5.2左侧功能列表按钮icon和文字重叠，代理页面样式并不统一的问题
<img width="1280" height="256" alt="QQ20260720-040442" src="https://github.com/user-attachments/assets/8b098017-b4b1-4e43-ba81-1a714674baaf" />
对2.5.2的新动画样式做了适配